### PR TITLE
GPC-NONE: Remove duplicate package name

### DIFF
--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/e2e/AcquirerTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/e2e/AcquirerTest.kt
@@ -1,9 +1,9 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.e2e
+package uk.gov.gdx.datashare.e2e
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.e2e.http.Api
+import uk.gov.gdx.datashare.e2e.http.Api
 import java.util.*
 
 @Tag("E2E")

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/e2e/Config.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/e2e/Config.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.e2e
+package uk.gov.gdx.datashare.e2e
 
 import java.net.URI
 

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/e2e/SupplierTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/e2e/SupplierTest.kt
@@ -1,9 +1,9 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.e2e
+package uk.gov.gdx.datashare.e2e
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.e2e.http.Api
+import uk.gov.gdx.datashare.e2e.http.Api
 import java.util.*
 
 @Tag("E2E")

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/e2e/http/Api.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/e2e/http/Api.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.e2e.http
+package uk.gov.gdx.datashare.e2e.http
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import uk.gov.gdx.datashare.config.JacksonConfiguration
@@ -9,7 +9,7 @@ import uk.gov.gdx.datashare.repositories.Acquirer
 import uk.gov.gdx.datashare.repositories.AcquirerSubscription
 import uk.gov.gdx.datashare.repositories.Supplier
 import uk.gov.gdx.datashare.repositories.SupplierSubscription
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.e2e.Config
+import uk.gov.gdx.datashare.e2e.Config
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/e2e/http/Api.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/e2e/http/Api.kt
@@ -2,6 +2,7 @@ package uk.gov.gdx.datashare.e2e.http
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import uk.gov.gdx.datashare.config.JacksonConfiguration
+import uk.gov.gdx.datashare.e2e.Config
 import uk.gov.gdx.datashare.enums.EnrichmentField
 import uk.gov.gdx.datashare.enums.EventType
 import uk.gov.gdx.datashare.models.*
@@ -9,7 +10,6 @@ import uk.gov.gdx.datashare.repositories.Acquirer
 import uk.gov.gdx.datashare.repositories.AcquirerSubscription
 import uk.gov.gdx.datashare.repositories.Supplier
 import uk.gov.gdx.datashare.repositories.SupplierSubscription
-import uk.gov.gdx.datashare.e2e.Config
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/e2e/http/AuthHelper.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/e2e/http/AuthHelper.kt
@@ -1,9 +1,9 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.e2e.http
+package uk.gov.gdx.datashare.e2e.http
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.e2e.Config
+import uk.gov.gdx.datashare.e2e.Config
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/helpers/builders/AcquirerBuilder.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/helpers/builders/AcquirerBuilder.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders
+package uk.gov.gdx.datashare.helpers.builders
 
 import uk.gov.gdx.datashare.repositories.Acquirer
 import java.time.LocalDateTime

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/helpers/builders/AcquirerEventBuilder.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/helpers/builders/AcquirerEventBuilder.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders
+package uk.gov.gdx.datashare.helpers.builders
 
 import uk.gov.gdx.datashare.repositories.AcquirerEvent
 import java.time.LocalDateTime

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/helpers/builders/AcquirerSubscriptionBuilder.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/helpers/builders/AcquirerSubscriptionBuilder.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders
+package uk.gov.gdx.datashare.helpers.builders
 
 import uk.gov.gdx.datashare.enums.EventType
 import uk.gov.gdx.datashare.repositories.AcquirerSubscription

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/helpers/builders/AcquirerSubscriptionEnrichmentFieldBuilder.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/helpers/builders/AcquirerSubscriptionEnrichmentFieldBuilder.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders
+package uk.gov.gdx.datashare.helpers.builders
 
 import uk.gov.gdx.datashare.enums.EnrichmentField
 import uk.gov.gdx.datashare.repositories.AcquirerSubscriptionEnrichmentField

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/helpers/builders/SupplierBuilder.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/helpers/builders/SupplierBuilder.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders
+package uk.gov.gdx.datashare.helpers.builders
 
 import uk.gov.gdx.datashare.repositories.Supplier
 import java.time.LocalDateTime

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/helpers/builders/SupplierEventBuilder.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/helpers/builders/SupplierEventBuilder.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders
+package uk.gov.gdx.datashare.helpers.builders
 
 import uk.gov.gdx.datashare.repositories.SupplierEvent
 import java.time.LocalDateTime

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/helpers/builders/SupplierSubscriptionBuilder.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/helpers/builders/SupplierSubscriptionBuilder.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders
+package uk.gov.gdx.datashare.helpers.builders
 
 import uk.gov.gdx.datashare.enums.EventType
 import uk.gov.gdx.datashare.repositories.SupplierSubscription

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/helpers/comparators.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/helpers/comparators.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers
+package uk.gov.gdx.datashare.helpers
 
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/MockIntegrationTestBase.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/MockIntegrationTestBase.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration
+package uk.gov.gdx.datashare.integration
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension
 import com.ninjasquad.springmockk.MockkBean

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/MockIntegrationTestBase.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/MockIntegrationTestBase.kt
@@ -7,7 +7,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.gdx.datashare.integration.IntegrationTestBase
 import uk.gov.gdx.datashare.queue.AwsQueueService
 import uk.gov.gdx.datashare.services.AcquirerEventProcessor
 import uk.gov.gdx.datashare.services.EventAcceptorService

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/actuator/PrometheusTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/actuator/PrometheusTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.actuator
+package uk.gov.gdx.datashare.integration.actuator
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/api/AcquirersControllerTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/api/AcquirersControllerTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.api
+package uk.gov.gdx.datashare.integration.api
 
 import org.junit.jupiter.api.Test
 import uk.gov.gdx.datashare.integration.SqsIntegrationTestBase

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/api/AdminControllerTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/api/AdminControllerTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.api
+package uk.gov.gdx.datashare.integration.api
 
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/api/EventsQueryTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/api/EventsQueryTest.kt
@@ -9,10 +9,10 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import uk.gov.gdx.datashare.enums.EventType
-import uk.gov.gdx.datashare.repositories.*
 import uk.gov.gdx.datashare.integration.MockIntegrationTestBase
 import uk.gov.gdx.datashare.integration.wiremock.mockLevApi
 import uk.gov.gdx.datashare.integration.wiremock.stubLevApiDeath
+import uk.gov.gdx.datashare.repositories.*
 import java.time.LocalDateTime
 import java.util.*
 

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/api/EventsQueryTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/api/EventsQueryTest.kt
@@ -10,9 +10,9 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import uk.gov.gdx.datashare.enums.EventType
 import uk.gov.gdx.datashare.repositories.*
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.MockIntegrationTestBase
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.wiremock.mockLevApi
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.wiremock.stubLevApiDeath
+import uk.gov.gdx.datashare.integration.MockIntegrationTestBase
+import uk.gov.gdx.datashare.integration.wiremock.mockLevApi
+import uk.gov.gdx.datashare.integration.wiremock.stubLevApiDeath
 import java.time.LocalDateTime
 import java.util.*
 

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/api/SuppliersControllerTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/api/SuppliersControllerTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.api
+package uk.gov.gdx.datashare.integration.api
 
 import org.junit.jupiter.api.Test
 import uk.gov.gdx.datashare.integration.SqsIntegrationTestBase

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/AcquirerEventRepositoryTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/AcquirerEventRepositoryTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.repository
+package uk.gov.gdx.datashare.integration.repository
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -6,9 +6,9 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.gdx.datashare.enums.EventType
 import uk.gov.gdx.datashare.repositories.*
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders.*
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.compareIgnoringNanos
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.MockIntegrationTestBase
+import uk.gov.gdx.datashare.helpers.builders.*
+import uk.gov.gdx.datashare.helpers.compareIgnoringNanos
+import uk.gov.gdx.datashare.integration.MockIntegrationTestBase
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 import java.util.*

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/AcquirerEventRepositoryTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/AcquirerEventRepositoryTest.kt
@@ -5,10 +5,10 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.repository.findByIdOrNull
 import uk.gov.gdx.datashare.enums.EventType
-import uk.gov.gdx.datashare.repositories.*
 import uk.gov.gdx.datashare.helpers.builders.*
 import uk.gov.gdx.datashare.helpers.compareIgnoringNanos
 import uk.gov.gdx.datashare.integration.MockIntegrationTestBase
+import uk.gov.gdx.datashare.repositories.*
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 import java.util.*

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/AcquirerRepositoryTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/AcquirerRepositoryTest.kt
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.gdx.datashare.repositories.AcquirerRepository
 import uk.gov.gdx.datashare.repositories.AcquirerSubscriptionRepository
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders.AcquirerBuilder
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders.AcquirerSubscriptionBuilder
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.MockIntegrationTestBase
+import uk.gov.gdx.datashare.helpers.builders.AcquirerBuilder
+import uk.gov.gdx.datashare.helpers.builders.AcquirerSubscriptionBuilder
+import uk.gov.gdx.datashare.integration.MockIntegrationTestBase
 import java.time.LocalDateTime
 
 class AcquirerRepositoryTest(

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/AcquirerRepositoryTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/AcquirerRepositoryTest.kt
@@ -3,11 +3,11 @@ package uk.gov.gdx.datashare.integration.repository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.gdx.datashare.repositories.AcquirerRepository
-import uk.gov.gdx.datashare.repositories.AcquirerSubscriptionRepository
 import uk.gov.gdx.datashare.helpers.builders.AcquirerBuilder
 import uk.gov.gdx.datashare.helpers.builders.AcquirerSubscriptionBuilder
 import uk.gov.gdx.datashare.integration.MockIntegrationTestBase
+import uk.gov.gdx.datashare.repositories.AcquirerRepository
+import uk.gov.gdx.datashare.repositories.AcquirerSubscriptionRepository
 import java.time.LocalDateTime
 
 class AcquirerRepositoryTest(

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/AcquirerSubscriptionEnrichmentFieldRepositoryTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/AcquirerSubscriptionEnrichmentFieldRepositoryTest.kt
@@ -3,11 +3,11 @@ package uk.gov.gdx.datashare.integration.repository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.gdx.datashare.repositories.*
 import uk.gov.gdx.datashare.helpers.builders.AcquirerBuilder
 import uk.gov.gdx.datashare.helpers.builders.AcquirerSubscriptionBuilder
 import uk.gov.gdx.datashare.helpers.builders.AcquirerSubscriptionEnrichmentFieldBuilder
 import uk.gov.gdx.datashare.integration.MockIntegrationTestBase
+import uk.gov.gdx.datashare.repositories.*
 
 class AcquirerSubscriptionEnrichmentFieldRepositoryTest(
   @Autowired private val acquirerRepository: AcquirerRepository,

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/AcquirerSubscriptionEnrichmentFieldRepositoryTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/AcquirerSubscriptionEnrichmentFieldRepositoryTest.kt
@@ -4,10 +4,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.gdx.datashare.repositories.*
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders.AcquirerBuilder
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders.AcquirerSubscriptionBuilder
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders.AcquirerSubscriptionEnrichmentFieldBuilder
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.MockIntegrationTestBase
+import uk.gov.gdx.datashare.helpers.builders.AcquirerBuilder
+import uk.gov.gdx.datashare.helpers.builders.AcquirerSubscriptionBuilder
+import uk.gov.gdx.datashare.helpers.builders.AcquirerSubscriptionEnrichmentFieldBuilder
+import uk.gov.gdx.datashare.integration.MockIntegrationTestBase
 
 class AcquirerSubscriptionEnrichmentFieldRepositoryTest(
   @Autowired private val acquirerRepository: AcquirerRepository,

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/AcquirerSubscriptionRepositoryTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/AcquirerSubscriptionRepositoryTest.kt
@@ -4,10 +4,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.gdx.datashare.enums.EventType
-import uk.gov.gdx.datashare.repositories.*
 import uk.gov.gdx.datashare.helpers.builders.*
 import uk.gov.gdx.datashare.helpers.compareIgnoringNanos
 import uk.gov.gdx.datashare.integration.MockIntegrationTestBase
+import uk.gov.gdx.datashare.repositories.*
 import java.time.LocalDateTime
 
 class AcquirerSubscriptionRepositoryTest(

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/AcquirerSubscriptionRepositoryTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/AcquirerSubscriptionRepositoryTest.kt
@@ -1,13 +1,13 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.repository
+package uk.gov.gdx.datashare.integration.repository
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.gdx.datashare.enums.EventType
 import uk.gov.gdx.datashare.repositories.*
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders.*
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.compareIgnoringNanos
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.MockIntegrationTestBase
+import uk.gov.gdx.datashare.helpers.builders.*
+import uk.gov.gdx.datashare.helpers.compareIgnoringNanos
+import uk.gov.gdx.datashare.integration.MockIntegrationTestBase
 import java.time.LocalDateTime
 
 class AcquirerSubscriptionRepositoryTest(

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/SupplierEventRepositoryTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/SupplierEventRepositoryTest.kt
@@ -1,12 +1,12 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.repository
+package uk.gov.gdx.datashare.integration.repository
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.gdx.datashare.enums.EventType
 import uk.gov.gdx.datashare.repositories.*
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders.*
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.MockIntegrationTestBase
+import uk.gov.gdx.datashare.helpers.builders.*
+import uk.gov.gdx.datashare.integration.MockIntegrationTestBase
 import java.time.LocalDateTime
 
 class SupplierEventRepositoryTest(

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/SupplierEventRepositoryTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/SupplierEventRepositoryTest.kt
@@ -4,9 +4,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.gdx.datashare.enums.EventType
-import uk.gov.gdx.datashare.repositories.*
 import uk.gov.gdx.datashare.helpers.builders.*
 import uk.gov.gdx.datashare.integration.MockIntegrationTestBase
+import uk.gov.gdx.datashare.repositories.*
 import java.time.LocalDateTime
 
 class SupplierEventRepositoryTest(

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/SupplierRepositoryTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/SupplierRepositoryTest.kt
@@ -4,8 +4,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.gdx.datashare.repositories.SupplierRepository
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders.SupplierBuilder
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.MockIntegrationTestBase
+import uk.gov.gdx.datashare.helpers.builders.SupplierBuilder
+import uk.gov.gdx.datashare.integration.MockIntegrationTestBase
 import java.time.LocalDateTime
 
 class SupplierRepositoryTest(@Autowired private val supplierRepository: SupplierRepository) :

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/SupplierRepositoryTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/SupplierRepositoryTest.kt
@@ -3,9 +3,9 @@ package uk.gov.gdx.datashare.integration.repository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import uk.gov.gdx.datashare.repositories.SupplierRepository
 import uk.gov.gdx.datashare.helpers.builders.SupplierBuilder
 import uk.gov.gdx.datashare.integration.MockIntegrationTestBase
+import uk.gov.gdx.datashare.repositories.SupplierRepository
 import java.time.LocalDateTime
 
 class SupplierRepositoryTest(@Autowired private val supplierRepository: SupplierRepository) :

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/SupplierSubscriptionRepositoryTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/SupplierSubscriptionRepositoryTest.kt
@@ -4,10 +4,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.gdx.datashare.enums.EventType
-import uk.gov.gdx.datashare.repositories.*
 import uk.gov.gdx.datashare.helpers.builders.*
 import uk.gov.gdx.datashare.helpers.compareIgnoringNanos
 import uk.gov.gdx.datashare.integration.MockIntegrationTestBase
+import uk.gov.gdx.datashare.repositories.*
 import java.time.LocalDateTime
 
 class SupplierSubscriptionRepositoryTest(

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/SupplierSubscriptionRepositoryTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/repository/SupplierSubscriptionRepositoryTest.kt
@@ -1,13 +1,13 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.repository
+package uk.gov.gdx.datashare.integration.repository
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.gdx.datashare.enums.EventType
 import uk.gov.gdx.datashare.repositories.*
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders.*
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.compareIgnoringNanos
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.MockIntegrationTestBase
+import uk.gov.gdx.datashare.helpers.builders.*
+import uk.gov.gdx.datashare.helpers.compareIgnoringNanos
+import uk.gov.gdx.datashare.integration.MockIntegrationTestBase
 import java.time.LocalDateTime
 
 class SupplierSubscriptionRepositoryTest(

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/wiremock/LevApi.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/integration/wiremock/LevApi.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.integration.wiremock
+package uk.gov.gdx.datashare.integration.wiremock
 
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/models/AcquirerSubRequestTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/models/AcquirerSubRequestTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import uk.gov.gdx.datashare.enums.EventType
-import uk.gov.gdx.datashare.models.AcquirerSubRequest
 
 class AcquirerSubRequestTest {
   private val validator: Validator = Validation.buildDefaultValidatorFactory().validator

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/models/AcquirerSubRequestTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/models/AcquirerSubRequestTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.models
+package uk.gov.gdx.datashare.models
 
 import jakarta.validation.Validation
 import jakarta.validation.Validator

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/models/DeathNotificationDetailsTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/models/DeathNotificationDetailsTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.models
+package uk.gov.gdx.datashare.models
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/models/DeathNotificationDetailsTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/models/DeathNotificationDetailsTest.kt
@@ -5,9 +5,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.gdx.datashare.enums.EnrichmentField
 import uk.gov.gdx.datashare.enums.Sex
-import uk.gov.gdx.datashare.models.DeathNotificationDetails
-import uk.gov.gdx.datashare.models.LevDeathRecord
-import uk.gov.gdx.datashare.models.LevDeceased
 import java.time.LocalDate
 
 class DeathNotificationDetailsTest {

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/services/AcquirerEventAuditServiceTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/services/AcquirerEventAuditServiceTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.services
+package uk.gov.gdx.datashare.services
 
 import io.mockk.every
 import io.mockk.mockk

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/services/AcquirerEventAuditServiceTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/services/AcquirerEventAuditServiceTest.kt
@@ -20,7 +20,6 @@ import uk.gov.gdx.datashare.models.DeathNotificationDetails
 import uk.gov.gdx.datashare.models.EventNotification
 import uk.gov.gdx.datashare.repositories.AcquirerEventAudit
 import uk.gov.gdx.datashare.repositories.AcquirerEventAuditRepository
-import uk.gov.gdx.datashare.services.AcquirerEventAuditService
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/services/AcquirerEventProcessorTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/services/AcquirerEventProcessorTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.services
+package uk.gov.gdx.datashare.services
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.mockk.every
@@ -17,8 +17,8 @@ import uk.gov.gdx.datashare.services.AcquirerEventAuditService
 import uk.gov.gdx.datashare.services.AcquirerEventProcessor
 import uk.gov.gdx.datashare.services.AcquirerEventService
 import uk.gov.gdx.datashare.services.OutboundEventQueueService
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders.AcquirerEventBuilder
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders.AcquirerSubscriptionBuilder
+import uk.gov.gdx.datashare.helpers.builders.AcquirerEventBuilder
+import uk.gov.gdx.datashare.helpers.builders.AcquirerSubscriptionBuilder
 import java.util.*
 
 class AcquirerEventProcessorTest {

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/services/AcquirerEventProcessorTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/services/AcquirerEventProcessorTest.kt
@@ -8,17 +8,13 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.springframework.data.repository.findByIdOrNull
+import uk.gov.gdx.datashare.helpers.builders.AcquirerEventBuilder
+import uk.gov.gdx.datashare.helpers.builders.AcquirerSubscriptionBuilder
 import uk.gov.gdx.datashare.models.EventNotification
 import uk.gov.gdx.datashare.repositories.AcquirerEvent
 import uk.gov.gdx.datashare.repositories.AcquirerEventRepository
 import uk.gov.gdx.datashare.repositories.AcquirerSubscription
 import uk.gov.gdx.datashare.repositories.AcquirerSubscriptionRepository
-import uk.gov.gdx.datashare.services.AcquirerEventAuditService
-import uk.gov.gdx.datashare.services.AcquirerEventProcessor
-import uk.gov.gdx.datashare.services.AcquirerEventService
-import uk.gov.gdx.datashare.services.OutboundEventQueueService
-import uk.gov.gdx.datashare.helpers.builders.AcquirerEventBuilder
-import uk.gov.gdx.datashare.helpers.builders.AcquirerSubscriptionBuilder
 import java.util.*
 
 class AcquirerEventProcessorTest {

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/services/AdminActionAlertsServiceTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/services/AdminActionAlertsServiceTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.services
+package uk.gov.gdx.datashare.services
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.mockk.every

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/services/AdminActionAlertsServiceTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/services/AdminActionAlertsServiceTest.kt
@@ -12,8 +12,6 @@ import org.springframework.security.core.context.SecurityContextHolder
 import software.amazon.awssdk.services.sns.SnsClient
 import software.amazon.awssdk.services.sns.model.PublishRequest
 import software.amazon.awssdk.services.sns.model.PublishResponse
-import uk.gov.gdx.datashare.services.AdminAction
-import uk.gov.gdx.datashare.services.AdminActionAlertsService
 
 class AdminActionAlertsServiceTest {
   private val objectMapper = mockk<ObjectMapper>()

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/services/GroApiServiceTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/services/GroApiServiceTest.kt
@@ -14,8 +14,6 @@ import uk.gov.gdx.datashare.models.GroDeleteEventResponse
 import uk.gov.gdx.datashare.models.GroEnrichEventResponse
 import uk.gov.gdx.datashare.repositories.SupplierEvent
 import uk.gov.gdx.datashare.repositories.SupplierEventRepository
-import uk.gov.gdx.datashare.services.GroApiService
-import uk.gov.gdx.datashare.services.LambdaService
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/services/GroApiServiceTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/services/GroApiServiceTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.services
+package uk.gov.gdx.datashare.services
 
 import io.mockk.*
 import org.assertj.core.api.Assertions.assertThat

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/services/GroDeathNotificationServiceTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/services/GroDeathNotificationServiceTest.kt
@@ -7,8 +7,6 @@ import org.junit.jupiter.api.Test
 import uk.gov.gdx.datashare.enums.EnrichmentField
 import uk.gov.gdx.datashare.enums.GroSex
 import uk.gov.gdx.datashare.models.GroDeathRecord
-import uk.gov.gdx.datashare.services.GroApiService
-import uk.gov.gdx.datashare.services.GroDeathNotificationService
 import java.time.LocalDate
 
 class GroDeathNotificationServiceTest {

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/services/GroDeathNotificationServiceTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/services/GroDeathNotificationServiceTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.services
+package uk.gov.gdx.datashare.services
 
 import io.mockk.every
 import io.mockk.mockk

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/services/LambdaServiceTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/services/LambdaServiceTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.services
+package uk.gov.gdx.datashare.services
 
 import io.mockk.every
 import io.mockk.mockk

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/services/LambdaServiceTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/services/LambdaServiceTest.kt
@@ -16,7 +16,6 @@ import uk.gov.gdx.datashare.enums.GroSex
 import uk.gov.gdx.datashare.models.GroDeathRecord
 import uk.gov.gdx.datashare.models.GroDeleteEventResponse
 import uk.gov.gdx.datashare.models.GroEnrichEventResponse
-import uk.gov.gdx.datashare.services.LambdaService
 import java.time.LocalDate
 
 class LambdaServiceTest {

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/services/OutboundEventQueueServiceTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/services/OutboundEventQueueServiceTest.kt
@@ -16,7 +16,7 @@ import software.amazon.awssdk.services.sts.StsClient
 import uk.gov.gdx.datashare.queue.AwsQueueFactory
 import uk.gov.gdx.datashare.queue.SqsProperties
 import uk.gov.gdx.datashare.repositories.AcquirerSubscriptionRepository
-import uk.gov.gdx.datashare.uk.gov.gdx.datashare.helpers.builders.AcquirerSubscriptionBuilder
+import uk.gov.gdx.datashare.helpers.builders.AcquirerSubscriptionBuilder
 
 class OutboundEventQueueServiceTest {
   private val environment = "test"

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/services/OutboundEventQueueServiceTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/services/OutboundEventQueueServiceTest.kt
@@ -13,10 +13,10 @@ import software.amazon.awssdk.services.kms.model.*
 import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sqs.model.*
 import software.amazon.awssdk.services.sts.StsClient
+import uk.gov.gdx.datashare.helpers.builders.AcquirerSubscriptionBuilder
 import uk.gov.gdx.datashare.queue.AwsQueueFactory
 import uk.gov.gdx.datashare.queue.SqsProperties
 import uk.gov.gdx.datashare.repositories.AcquirerSubscriptionRepository
-import uk.gov.gdx.datashare.helpers.builders.AcquirerSubscriptionBuilder
 
 class OutboundEventQueueServiceTest {
   private val environment = "test"

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/services/ScheduledJobServiceTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/services/ScheduledJobServiceTest.kt
@@ -13,10 +13,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
 import uk.gov.gdx.datashare.repositories.*
-import uk.gov.gdx.datashare.services.GroApiService
-import uk.gov.gdx.datashare.services.OutboundEventQueueService
-import uk.gov.gdx.datashare.services.QueueMetric
-import uk.gov.gdx.datashare.services.ScheduledJobService
 import java.util.*
 import java.util.concurrent.atomic.AtomicInteger
 

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/services/ScheduledJobServiceTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/services/ScheduledJobServiceTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.services
+package uk.gov.gdx.datashare.services
 
 import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/services/SupplierEventProcessorTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/services/SupplierEventProcessorTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.gdx.datashare.uk.gov.gdx.datashare.services
+package uk.gov.gdx.datashare.services
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.mockk.*

--- a/platform/src/test/kotlin/uk/gov/gdx/datashare/services/SupplierEventProcessorTest.kt
+++ b/platform/src/test/kotlin/uk/gov/gdx/datashare/services/SupplierEventProcessorTest.kt
@@ -15,7 +15,6 @@ import uk.gov.gdx.datashare.enums.EventType
 import uk.gov.gdx.datashare.queue.AwsQueue
 import uk.gov.gdx.datashare.queue.AwsQueueService
 import uk.gov.gdx.datashare.repositories.*
-import uk.gov.gdx.datashare.services.SupplierEventProcessor
 import java.time.LocalDateTime
 import java.util.*
 


### PR DESCRIPTION
Stealing @oskarwilliams thunder a bit, but this felt worth splitting out