### PR TITLE
GPC-470: Suppress CVE-2023-2975

### DIFF
--- a/grafana/.trivyignore
+++ b/grafana/.trivyignore
@@ -11,3 +11,6 @@ CVE-2023-2650
 
 # GPC-444: This vulnerability is fairly difficult to execute, and only allows for data exfiltration from our Grafana monitoring, which contains no secure information.
 CVE-2023-32731
+
+# GPC-470: Only affect empty authentication data, which does not impact us
+CVE-2023-2975

--- a/prometheus/.trivyignore
+++ b/prometheus/.trivyignore
@@ -8,3 +8,6 @@ CVE-2023-2650
 
 # GPC-464: This is not an issue as it requires access to creating jaeger traces on our container that is not publicly accessible.
 GHSA-2w8w-qhg4-f78j
+
+# GPC-470: Only affect empty authentication data, which does not impact us
+CVE-2023-2975


### PR DESCRIPTION
As this issue does not affect non-empty associated data authentication and we expect it to be rare for an application to use empty associated data entries this is qualified as Low severity issue.

Does not affect us.