### PR TITLE
GPC-NONE: Add allow rules to VPC

### DIFF
--- a/stack-orchestration/configuration/build/vpc/parameters.json
+++ b/stack-orchestration/configuration/build/vpc/parameters.json
@@ -4,6 +4,10 @@
     "ParameterValue": "cognito-idp.eu-west-2.amazonaws.com"
   },
   {
+    "ParameterKey": "AllowRules",
+    "ParameterValue": "pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; content:\"cognito-idp.eu-west-2.amazonaws.com\"; startswith; endswith; msg:\"Pass TLS to cognito-idp.eu-west-2.amazonaws.com\"; flow:established; sid:2001; rev:1;)"
+  },
+  {
     "ParameterKey": "SNSApiEnabled",
     "ParameterValue": "Yes"
   },

--- a/stack-orchestration/configuration/dev/vpc/parameters.json
+++ b/stack-orchestration/configuration/dev/vpc/parameters.json
@@ -4,6 +4,10 @@
     "ParameterValue": "cognito-idp.eu-west-2.amazonaws.com"
   },
   {
+    "ParameterKey": "AllowRules",
+    "ParameterValue": "pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; content:\"cognito-idp.eu-west-2.amazonaws.com\"; startswith; endswith; msg:\"Pass TLS to cognito-idp.eu-west-2.amazonaws.com\"; flow:established; sid:2001; rev:1;)"
+  },
+  {
     "ParameterKey": "SNSApiEnabled",
     "ParameterValue": "Yes"
   },

--- a/stack-orchestration/configuration/integration/vpc/parameters.json
+++ b/stack-orchestration/configuration/integration/vpc/parameters.json
@@ -4,6 +4,10 @@
     "ParameterValue": "cognito-idp.eu-west-2.amazonaws.com"
   },
   {
+    "ParameterKey": "AllowRules",
+    "ParameterValue": "pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; content:\"cognito-idp.eu-west-2.amazonaws.com\"; startswith; endswith; msg:\"Pass TLS to cognito-idp.eu-west-2.amazonaws.com\"; flow:established; sid:2001; rev:1;)"
+  },
+  {
     "ParameterKey": "SNSApiEnabled",
     "ParameterValue": "Yes"
   },

--- a/stack-orchestration/configuration/production/vpc/parameters.json
+++ b/stack-orchestration/configuration/production/vpc/parameters.json
@@ -4,6 +4,10 @@
     "ParameterValue": "cognito-idp.eu-west-2.amazonaws.com"
   },
   {
+    "ParameterKey": "AllowRules",
+    "ParameterValue": "pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; content:\"cognito-idp.eu-west-2.amazonaws.com\"; startswith; endswith; msg:\"Pass TLS to cognito-idp.eu-west-2.amazonaws.com\"; flow:established; sid:2001; rev:1;)"
+  },
+  {
     "ParameterKey": "SNSApiEnabled",
     "ParameterValue": "Yes"
   },

--- a/stack-orchestration/configuration/staging/vpc/parameters.json
+++ b/stack-orchestration/configuration/staging/vpc/parameters.json
@@ -4,6 +4,10 @@
     "ParameterValue": "cognito-idp.eu-west-2.amazonaws.com"
   },
   {
+    "ParameterKey": "AllowRules",
+    "ParameterValue": "pass tls $HOME_NET any -> $EXTERNAL_NET 443 (tls.sni; content:\"cognito-idp.eu-west-2.amazonaws.com\"; startswith; endswith; msg:\"Pass TLS to cognito-idp.eu-west-2.amazonaws.com\"; flow:established; sid:2001; rev:1;)"
+  },
+  {
     "ParameterKey": "SNSApiEnabled",
     "ParameterValue": "Yes"
   },


### PR DESCRIPTION
Cognito integration requires access from lambdas through the VPC to the relevant cognito idp url. This is not provided by an AWS VPC endpoint, so we have to configure both AllowedDomains and AllowRules in our VPC stack