### PR TITLE
GPC-NONE: Fix KMS Key ID to be ARN

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -194,7 +194,7 @@ Resources:
     Properties:
       LogGroupName: !Sub "/aws/apigateway/${AWS::StackName}-access-logs"
       RetentionInDays: 14
-      KmsKeyId: !Ref MainKmsKey
+      KmsKeyId: !GetAtt MainKmsKey.Arn
 
   AuthorisationDlq:
     Type: AWS::SQS::Queue


### PR DESCRIPTION
AWS::Logs::LogGroup property KmsKeyId does not take the Key ID, it takes the Key ARN, updated to reflect that