### PR TITLE
GPC-NONE: Add appspec back into ci folder

### DIFF
--- a/ci/appspec-template.json
+++ b/ci/appspec-template.json
@@ -1,0 +1,23 @@
+{
+  "version": 0.0,
+  "Resources": [
+    {
+      "TargetService": {
+        "Type": "AWS::ECS::Service",
+        "Properties": {
+          "TaskDefinition": "arn:aws:ecs:aws-region-id:aws-account-id:task-definition/ecs-demo-task-definition:revision-number",
+          "LoadBalancerInfo": {
+            "ContainerName": "your-container-name",
+            "ContainerPort": "your-container-port"
+          },
+          "PlatformVersion": "LATEST"
+        }
+      }
+    }
+  ],
+  "Hooks": [
+    {
+      "AfterAllowTestTraffic": "lambda-hook"
+    }
+  ]
+}


### PR DESCRIPTION
`appspec-template.json` got deleted when I was removing security hub, this PR adds it back in to fix our failing deployments to the old service