### PR TITLE
GPC-NONE: Tidy cloudformation template

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -46,27 +46,27 @@ Parameters:
   CodeSigningConfigArn:
     Type: String
     Description: The ARN of the Code Signing Config to use, provided by the deployment pipeline
-    Default: "none"
+    Default: none
   PermissionsBoundary:
     Type: String
     Description: The ARN of the permissions boundary to apply when creating IAM roles
-    Default: "none"
+    Default: none
 
 Conditions:
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:
           - !Ref CodeSigningConfigArn
-          - "none"
+          - none
   UsePermissionsBoundary:
     Fn::Not:
       - Fn::Equals:
           - !Ref PermissionsBoundary
-          - "none"
+          - none
   IsDev:
     Fn::Equals:
       - !Ref Environment
-      - "dev"
+      - dev
 #  IsNotDev: !Not [ !Condition IsDev ]
 
 Mappings:
@@ -92,28 +92,28 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
-            Action: "kms:*"
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
             Resource: "*"
           - Effect: Allow
             Principal:
-              Service: !Sub "logs.${AWS::Region}.amazonaws.com"
+              Service: !Sub logs.${AWS::Region}.amazonaws.com
             Action:
-              - "kms:Encrypt*"
-              - "kms:Decrypt*"
-              - "kms:ReEncrypt*"
-              - "kms:GenerateDataKey*"
-              - "kms:Describe*"
+              - kms:Encrypt*
+              - kms:Decrypt*
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:Describe*
             Resource: "*"
             Condition:
               ArnLike:
-                "kms:EncryptionContext:aws:logs:arn": !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+                kms:EncryptionContext:aws:logs:arn: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
           - Effect: Allow
             Principal:
-              Service: "sns.amazonaws.com"
+              Service: sns.amazonaws.com
             Action:
-              - "kms:Decrypt"
-              - "kms:GenerateDataKey*"
+              - kms:Decrypt
+              - kms:GenerateDataKey*
             Resource: "*"
 
   LogsBucket:
@@ -124,9 +124,9 @@ Resources:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
-              SSEAlgorithm: 'aws:kms'
+              SSEAlgorithm: aws:kms
               KMSMasterKeyID: !Ref MainKmsKey
-      BucketName: !Sub "${Environment}${Developer}-life-events-logs-bucket"
+      BucketName: !Sub ${Environment}${Developer}-life-events-logs-bucket
       NotificationConfiguration:
         EventBridgeConfiguration:
           EventBridgeEnabled: true
@@ -215,12 +215,12 @@ Resources:
           "responseLength":"$context.responseLength"
           }
       Tags:
-        CheckovRulesToSkip: "CKV_AWS_120"
+        CheckovRulesToSkip: CKV_AWS_120
 
   ApiGatewayLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub "/aws/apigateway/${AWS::StackName}-access-logs"
+      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-access-logs
       RetentionInDays: 14
       KmsKeyId: !GetAtt MainKmsKey.Arn
 
@@ -229,7 +229,7 @@ Resources:
 #    Type: AWS::Logs::SubscriptionFilter
 #    Condition: IsNotDev
 #    Properties:
-#      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+#      DestinationArn: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
 #      FilterPattern: ""
 #      LogGroupName: !Ref ApiGatewayLogGroup
 
@@ -266,12 +266,12 @@ Resources:
     Type: AWS::SQS::QueuePolicy
     Properties:
       PolicyDocument:
-        Version: "2012-10-17"
+        Version: 2012-10-17
         Statement:
-          - Sid: "Allow SNS publish to SQS"
+          - Sid: Allow SNS publish to SQS
             Effect: Allow
             Principal:
-              Service: "sns.amazonaws.com"
+              Service: sns.amazonaws.com
             Resource: "*"
             Action: SQS:SendMessage
             Condition:
@@ -329,7 +329,7 @@ Resources:
       # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_117: VPC settings are set globally.
       # checkov:skip=CKV_AWS_173: Encryption settings are set globally.
-      FunctionName: !Sub "authorisation-${Environment}${Developer}"
+      FunctionName: !Sub authorisation-${Environment}${Developer}
       CodeUri: lambdas/authorisation
       Handler: uk.gov.di.data.lep.Authorisation::handleRequest
       Environment:
@@ -345,8 +345,8 @@ Resources:
             - Sid: KmsMasterKeyAccess
               Effect: Allow
               Action:
-                - 'kms:Decrypt'
-                - 'kms:GenerateDataKey'
+                - kms:Decrypt
+                - kms:GenerateDataKey
               Resource:
                 - !GetAtt MainKmsKey.Arn
       VpcConfig:
@@ -355,13 +355,13 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-ProtectedSubnetIdC
       Tags:
-        CheckovRulesToSkip: "CKV_AWS_115.CKV_AWS_117.CKV_AWS_173"
+        CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_117.CKV_AWS_173
 
   AuthorisationFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       RetentionInDays: 14
-      LogGroupName: !Sub "/aws/lambda/authorisation-${Environment}${Developer}"
+      LogGroupName: !Sub /aws/lambda/authorisation-${Environment}${Developer}
       KmsKeyId: !GetAtt MainKmsKey.Arn
 
 # Comment out CSLS subscription filters until accounts have been granted access
@@ -369,7 +369,7 @@ Resources:
 #    Type: AWS::Logs::SubscriptionFilter
 #    Condition: IsNotDev
 #    Properties:
-#      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+#      DestinationArn: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
 #      FilterPattern: ""
 #      LogGroupName: !Ref AuthorisationFunctionLogGroup
 
@@ -381,7 +381,7 @@ Resources:
       # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_117: VPC settings are set globally.
       # checkov:skip=CKV_AWS_173: Encryption settings are set globally.
-      FunctionName: !Sub "death-validation-${Environment}${Developer}"
+      FunctionName: !Sub death-validation-${Environment}${Developer}
       CodeUri: lambdas/death-validation
       Handler: uk.gov.di.data.lep.GroDeathValidation::handleRequest
       Environment:
@@ -404,8 +404,8 @@ Resources:
             - Sid: KmsMasterKeyAccess
               Effect: Allow
               Action:
-                - 'kms:Decrypt'
-                - 'kms:GenerateDataKey'
+                - kms:Decrypt
+                - kms:GenerateDataKey
               Resource:
                 - !GetAtt MainKmsKey.Arn
         - SQSSendMessagePolicy:
@@ -416,13 +416,13 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
       Tags:
-        CheckovRulesToSkip: "CKV_AWS_115.CKV_AWS_117.CKV_AWS_173"
+        CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_117.CKV_AWS_173
 
   DeathValidationFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       RetentionInDays: 14
-      LogGroupName: !Sub "/aws/lambda/death-validation-${Environment}${Developer}"
+      LogGroupName: !Sub /aws/lambda/death-validation-${Environment}${Developer}
       KmsKeyId: !GetAtt MainKmsKey.Arn
 
 # Comment out CSLS subscription filters until accounts have been granted access
@@ -430,7 +430,7 @@ Resources:
 #    Type: AWS::Logs::SubscriptionFilter
 #    Condition: IsNotDev
 #    Properties:
-#      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+#      DestinationArn: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
 #      FilterPattern: ""
 #      LogGroupName: !Ref DeathValidationFunctionLogGroup
 
@@ -442,7 +442,7 @@ Resources:
       # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_117: VPC settings are set globally.
       # checkov:skip=CKV_AWS_173: Encryption settings are set globally.
-      FunctionName: !Sub "death-enrichment-${Environment}${Developer}"
+      FunctionName: !Sub death-enrichment-${Environment}${Developer}
       CodeUri: lambdas/death-enrichment
       Handler: uk.gov.di.data.lep.GroDeathEnrichment::handleRequest
       Environment:
@@ -464,8 +464,8 @@ Resources:
             - Sid: KmsMasterKeyAccess
               Effect: Allow
               Action:
-                - 'kms:Decrypt'
-                - 'kms:GenerateDataKey'
+                - kms:Decrypt
+                - kms:GenerateDataKey
               Resource:
                 - !GetAtt MainKmsKey.Arn
         - SNSPublishMessagePolicy:
@@ -476,13 +476,13 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
       Tags:
-        CheckovRulesToSkip: "CKV_AWS_115.CKV_AWS_117.CKV_AWS_173"
+        CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_117.CKV_AWS_173
 
   DeathEnrichmentFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       RetentionInDays: 14
-      LogGroupName: !Sub "/aws/lambda/death-enrichment-${Environment}${Developer}"
+      LogGroupName: !Sub /aws/lambda/death-enrichment-${Environment}${Developer}
       KmsKeyId: !GetAtt MainKmsKey.Arn
 
 # Comment out CSLS subscription filters until accounts have been granted access
@@ -490,7 +490,7 @@ Resources:
 #    Type: AWS::Logs::SubscriptionFilter
 #    Condition: IsNotDev
 #    Properties:
-#      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+#      DestinationArn: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
 #      FilterPattern: ""
 #      LogGroupName: !Ref DeathEnrichmentFunctionLogGroup
 
@@ -502,7 +502,7 @@ Resources:
       # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
       # checkov:skip=CKV_AWS_117: VPC settings are set globally.
       # checkov:skip=CKV_AWS_173: Encryption settings are set globally.
-      FunctionName: !Sub "death-minimisation-${Environment}${Developer}"
+      FunctionName: !Sub death-minimisation-${Environment}${Developer}
       CodeUri: lambdas/death-minimisation
       Handler: uk.gov.di.data.lep.GroDeathNotificationMinimisation::handleRequest
       Environment:
@@ -525,8 +525,8 @@ Resources:
             - Sid: KmsMasterKeyAccess
               Effect: Allow
               Action:
-                - 'kms:Decrypt'
-                - 'kms:GenerateDataKey'
+                - kms:Decrypt
+                - kms:GenerateDataKey
               Resource:
                 - !GetAtt MainKmsKey.Arn
         - SQSSendMessagePolicy:
@@ -537,13 +537,13 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
       Tags:
-        CheckovRulesToSkip: "CKV_AWS_115.CKV_AWS_117.CKV_AWS_173"
+        CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_117.CKV_AWS_173
 
   DeathMinimisationFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       RetentionInDays: 14
-      LogGroupName: !Sub "/aws/lambda/death-minimisation-${Environment}${Developer}"
+      LogGroupName: !Sub /aws/lambda/death-minimisation-${Environment}${Developer}
       KmsKeyId: !GetAtt MainKmsKey.Arn
 
 # Comment out CSLS subscription filters until accounts have been granted access
@@ -551,7 +551,7 @@ Resources:
 #    Type: AWS::Logs::SubscriptionFilter
 #    Condition: IsNotDev
 #    Properties:
-#      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+#      DestinationArn: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
 #      FilterPattern: ""
 #      LogGroupName: !Ref DeathMinimisationFunctionLogGroup
 
@@ -610,13 +610,13 @@ Resources:
   UserPool:
     Type: AWS::Cognito::UserPool
     Properties:
-      UserPoolName: !Sub "UserPool-${Environment}${Developer}"
+      UserPoolName: !Sub UserPool-${Environment}${Developer}
 
   UserPoolDomain:
     Type: AWS::Cognito::UserPoolDomain
     Properties:
       UserPoolId: !Ref UserPool
-      Domain: !Sub "${Environment}${Developer}-life-events"
+      Domain: !Sub ${Environment}${Developer}-life-events
 
   UserPoolResourceServer:
     Type: AWS::Cognito::UserPoolResourceServer
@@ -624,8 +624,8 @@ Resources:
       Identifier: EventType
       Name: UserPoolResourceServer
       Scopes:
-        - ScopeDescription: "Can publish death notification events"
-          ScopeName: "DeathNotification"
+        - ScopeDescription: Can publish death notification events
+          ScopeName: DeathNotification
       UserPoolId: !Ref UserPool
 
   DeathNotificationClient:
@@ -635,20 +635,20 @@ Resources:
     Properties:
       AccessTokenValidity: 60
       AllowedOAuthFlows:
-        - "client_credentials"
+        - client_credentials
       AllowedOAuthFlowsUserPoolClient: true
       AllowedOAuthScopes:
         - EventType/DeathNotification
-      ClientName: "DeathNotificationClient"
+      ClientName: DeathNotificationClient
       EnableTokenRevocation: false
       ExplicitAuthFlows:
-        - "ALLOW_USER_PASSWORD_AUTH"
-        - "ALLOW_REFRESH_TOKEN_AUTH"
+        - ALLOW_USER_PASSWORD_AUTH
+        - ALLOW_REFRESH_TOKEN_AUTH
       GenerateSecret: true
-      PreventUserExistenceErrors: "ENABLED"
+      PreventUserExistenceErrors: ENABLED
       UserPoolId: !Ref UserPool
       TokenValidityUnits:
-        AccessToken: "minutes"
+        AccessToken: minutes
 
   GroIngestionBucket:
     Type: AWS::S3::Bucket
@@ -658,12 +658,12 @@ Resources:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
-              SSEAlgorithm: "aws:kms"
+              SSEAlgorithm: aws:kms
               KMSMasterKeyID: !Ref MainKmsKey
-      BucketName: !Sub "${Environment}${Developer}-life-events-gro-ingestion-bucket"
+      BucketName: !Sub ${Environment}${Developer}-life-events-gro-ingestion-bucket
       LoggingConfiguration:
         DestinationBucketName: !Ref LogsBucket
-        LogFilePrefix: "gro-ingestion-bucket/log"
+        LogFilePrefix: gro-ingestion-bucket/log
       NotificationConfiguration:
         EventBridgeConfiguration:
           EventBridgeEnabled: true
@@ -681,12 +681,12 @@ Resources:
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
-              SSEAlgorithm: "aws:kms"
+              SSEAlgorithm: aws:kms
               KMSMasterKeyID: !Ref MainKmsKey
-      BucketName: !Sub "${Environment}${Developer}-life-events-gro-records-bucket"
+      BucketName: !Sub ${Environment}${Developer}-life-events-gro-records-bucket
       LoggingConfiguration:
         DestinationBucketName: !Ref LogsBucket
-        LogFilePrefix: "gro-records-bucket/log"
+        LogFilePrefix: gro-records-bucket/log
       NotificationConfiguration:
         EventBridgeConfiguration:
           EventBridgeEnabled: true
@@ -699,7 +699,7 @@ Resources:
   GroIngestionStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:
-      Name: !Sub "${Environment}${Developer}-ingestion-state-machine"
+      Name: !Sub ${Environment}${Developer}-ingestion-state-machine
       DefinitionUri: groIngestionStepFunction.asl.json
       DefinitionSubstitutions:
         GroConvertToJsonFunctionArn: !GetAtt GroConvertToJsonFunction.Arn
@@ -710,9 +710,9 @@ Resources:
           Properties:
             Pattern:
               source:
-                - "aws.s3"
+                - aws.s3
               detail-type:
-                - "Object Created"
+                - Object Created
               detail:
                 bucket:
                   name:
@@ -725,28 +725,28 @@ Resources:
         - S3ReadPolicy:
             BucketName: !Ref GroRecordsBucket
         - StepFunctionsExecutionPolicy:
-            StateMachineName: !Sub "${Environment}${Developer}-ingestion-state-machine"
+            StateMachineName: !Sub ${Environment}${Developer}-ingestion-state-machine
         - Statement:
             - Sid: KmsMainKeyAccess
               Effect: Allow
               Action:
-                - 'kms:Decrypt'
-                - 'kms:GenerateDataKey'
+                - kms:Decrypt
+                - kms:GenerateDataKey
               Resource:
                 - !GetAtt MainKmsKey.Arn
         - Statement:
             - Sid: CloudWatchLogsAccess
               Effect: Allow
               Action:
-                - "logs:CreateLogDelivery"
-                - "logs:GetLogDelivery"
-                - "logs:UpdateLogDelivery"
-                - "logs:DeleteLogDelivery"
-                - "logs:ListLogDeliveries"
-                - "logs:PutLogEvents"
-                - "logs:PutResourcePolicy"
-                - "logs:DescribeResourcePolicies"
-                - "logs:DescribeLogGroups"
+                - logs:CreateLogDelivery
+                - logs:GetLogDelivery
+                - logs:UpdateLogDelivery
+                - logs:DeleteLogDelivery
+                - logs:ListLogDeliveries
+                - logs:PutLogEvents
+                - logs:PutResourcePolicy
+                - logs:DescribeResourcePolicies
+                - logs:DescribeLogGroups
               Resource: "*"
       Tracing:
         Enabled: true
@@ -764,7 +764,7 @@ Resources:
       # checkov:skip=CKV_AWS_116: We do not want this function to have a DLQ that could contain PII Data, on failure there should be no saved data.
       # checkov:skip=CKV_AWS_117: VPC settings are set globally.
       # checkov:skip=CKV_AWS_173: Encryption settings are set globally.
-      FunctionName: !Sub "gro-convert-to-json-${Environment}${Developer}"
+      FunctionName: !Sub gro-convert-to-json-${Environment}${Developer}
       CodeUri: lambdas/gro-convert-to-json
       Handler: uk.gov.di.data.lep.ConvertToJson::handleRequest
       Environment:
@@ -779,8 +779,8 @@ Resources:
             - Sid: KmsMasterKeyAccess
               Effect: Allow
               Action:
-                - 'kms:Decrypt'
-                - 'kms:GenerateDataKey'
+                - kms:Decrypt
+                - kms:GenerateDataKey
               Resource:
                 - !GetAtt MainKmsKey.Arn
       VpcConfig:
@@ -789,13 +789,13 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
       Tags:
-        CheckovRulesToSkip: "CKV_AWS_115.CKV_AWS_116.CKV_AWS_117.CKV_AWS_173"
+        CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_117.CKV_AWS_173
 
   GroConvertToJsonFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       RetentionInDays: 14
-      LogGroupName: !Sub "/aws/lambda/gro-convert-to-json-${Environment}${Developer}"
+      LogGroupName: !Sub /aws/lambda/gro-convert-to-json-${Environment}${Developer}
       KmsKeyId: !GetAtt MainKmsKey.Arn
 
 # Comment out CSLS subscription filters until accounts have been granted access
@@ -803,7 +803,7 @@ Resources:
 #    Type: AWS::Logs::SubscriptionFilter
 #    Condition: IsNotDev
 #    Properties:
-#      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+#      DestinationArn: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
 #      FilterPattern: ""
 #      LogGroupName: !Ref GroConvertToJsonFunctionLogGroup
 
@@ -816,7 +816,7 @@ Resources:
       # checkov:skip=CKV_AWS_116: We do not want this function to have a DLQ that could contain PII Data, on failure there should be no saved data.
       # checkov:skip=CKV_AWS_117: VPC settings are set globally.
       # checkov:skip=CKV_AWS_173: Encryption settings are set globally.
-      FunctionName: !Sub "gro-publish-record-${Environment}${Developer}"
+      FunctionName: !Sub gro-publish-record-${Environment}${Developer}
       CodeUri: lambdas/gro-publish-record
       Handler: uk.gov.di.data.lep.PublishRecord::handleRequest
       Environment:
@@ -828,8 +828,8 @@ Resources:
             - Sid: KmsMainKeyAccess
               Effect: Allow
               Action:
-                - 'kms:Decrypt'
-                - 'kms:GenerateDataKey'
+                - kms:Decrypt
+                - kms:GenerateDataKey
               Resource:
                 - !GetAtt MainKmsKey.Arn
       VpcConfig:
@@ -838,13 +838,13 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
       Tags:
-        CheckovRulesToSkip: "CKV_AWS_115.CKV_AWS_116.CKV_AWS_117.CKV_AWS_173"
+        CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_117.CKV_AWS_173
 
   GroPublishRecordFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       RetentionInDays: 14
-      LogGroupName: !Sub "/aws/lambda/gro-publish-record-${Environment}${Developer}"
+      LogGroupName: !Sub /aws/lambda/gro-publish-record-${Environment}${Developer}
       KmsKeyId: !GetAtt MainKmsKey.Arn
 
 # Comment out CSLS subscription filters until accounts have been granted access
@@ -852,6 +852,6 @@ Resources:
 #    Type: AWS::Logs::SubscriptionFilter
 #    Condition: IsNotDev
 #    Properties:
-#      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+#      DestinationArn: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
 #      FilterPattern: ""
 #      LogGroupName: !Ref GroPublishRecordFunctionLogGroup


### PR DESCRIPTION
Removes unnecessary quotes, and replaces single quotes with double. This is to keep consistency across the whole template