### PR TITLE
GPC-NONE: Update error catching to include input in output

### DIFF
--- a/groIngestionStepFunction.asl.json
+++ b/groIngestionStepFunction.asl.json
@@ -71,7 +71,8 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Next": "FailureDeleteJsonRecords"
+          "Next": "FailureDeleteJsonRecords",
+          "ResultPath": "$.Error"
         }
       ],
       "ResultPath": null


### PR DESCRIPTION
This is to make sure our failure delete json records step gets the input of the map which includes its buckets name and file key.