### PR TITLE
GPC-NONE: Update trivy skip

### DIFF
--- a/.github/workflows/scheduled-trivy-scan.yml
+++ b/.github/workflows/scheduled-trivy-scan.yml
@@ -101,7 +101,7 @@ jobs:
         with:
           scan-type: config
           trivyignores: .trivyignore.docker
-          skip-dirs: lev-data/
+          skip-dirs: lev-data/,stack-orchestration/
           skip-files: template.yaml
           exit-code: 1
           format: json

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -66,5 +66,5 @@ jobs:
 #          scan-type: config
 #          trivyignores: .trivyignore.docker
 #          exit-code: 1
-#          skip-dirs: lev-data/
+#          skip-dirs: lev-data/,stack-orchestration/
 #          skip-files: template.yaml


### PR DESCRIPTION
Update trivy to not scan cloudformation files already scanned by checkov