### PR TITLE
GPC-NONE: Split template into multiple applications to allow for more resources

### DIFF
--- a/.cfnlintrc.yaml
+++ b/.cfnlintrc.yaml
@@ -1,0 +1,2 @@
+ignore_checks:
+  - W3002 # We ignore this check as sam package is run during deploy now

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ resolve_s3 = true
 s3_prefix = "<your-name>-lev"
 region = "eu-west-2"
 confirm_changeset = true
-capabilities = "CAPABILITY_IAM"
+capabilities = "CAPABILITY_IAM CAPABILITY_AUTO_EXPAND"
 parameter_overrides = "Environment=\"dev\" VpcStackName=\"ia-Vpc-E5N71SHB6HRJ\" Developer=\"<your-name>\""
 ```
 

--- a/sam/deathAcquirerTemplate.yaml
+++ b/sam/deathAcquirerTemplate.yaml
@@ -1,0 +1,208 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >-
+  This creates the necessary serverless components for a Death Notification Acquirer for the Life Events Platform.
+
+
+Globals:
+  Function:
+    Timeout: 30
+    Environment:
+      Variables:
+        JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
+        POWERTOOLS_TRACER_CAPTURE_RESPONSE: false
+        POWERTOOLS_TRACER_CAPTURE_ERROR: false
+    Runtime: java17
+    Architectures:
+      - x86_64
+    MemorySize: 512
+    KmsKeyArn: !Ref MainKmsKeyArn
+    Tracing: Active
+    SnapStart:
+      ApplyOn: PublishedVersions
+    VpcConfig:
+      SecurityGroupIds:
+        - !Ref LambdaSecurityGroupId
+    CodeSigningConfigArn: !If
+      - UseCodeSigning
+      - !Ref CodeSigningConfigArn
+      - !Ref AWS::NoValue
+    PermissionsBoundary: !If
+      - UsePermissionsBoundary
+      - !Ref PermissionsBoundary
+      - !Ref AWS::NoValue
+
+Parameters:
+  Environment:
+    Type: String
+    Description: The name of the environment to deploy to
+  VpcStackName:
+    Type: String
+    Description: The name of the stack used to create the VPC
+  Developer:
+    Type: String
+    Description: The name of the developer running the stack in dev
+    Default: ""
+  DistributionTopicArn:
+    Type: String
+    Description: The distribution topic to subscribe to
+  MainKmsKeyId:
+    Type: String
+    Description: The main KMS key ID
+  MainKmsKeyArn:
+    Type: String
+    Description: The main KMS key ARN
+  LambdaSecurityGroupId:
+    Type: String
+    Description: The ID of the lambda security group
+  NamePrefix:
+    Type: String
+    Description: The name to prefix the resources with
+  CodeSigningConfigArn:
+    Type: String
+    Description: The ARN of the Code Signing Config to use, provided by the deployment pipeline
+    Default: none
+  PermissionsBoundary:
+    Type: String
+    Description: The ARN of the permissions boundary to apply when creating IAM roles
+    Default: none
+
+Conditions:
+  UseCodeSigning:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref CodeSigningConfigArn
+          - none
+  UsePermissionsBoundary:
+    Fn::Not:
+      - Fn::Equals:
+          - !Ref PermissionsBoundary
+          - none
+  IsDev:
+    Fn::Equals:
+      - !Ref Environment
+      - dev
+#  IsNotDev: !Not [ !Condition IsDev ]
+
+Resources:
+  DeathSnsToSqsPolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: Allow SNS publish to SQS
+            Effect: Allow
+            Principal:
+              Service: sns.amazonaws.com
+            Resource: "*"
+            Action: SQS:SendMessage
+            Condition:
+              ArnEquals:
+                aws:SourceArn: !Ref DistributionTopicArn
+      Queues:
+        - !GetAtt DeathMinimisationQueue.QueueUrl
+
+  DeathDistributionDlq:
+    Type: AWS::SQS::Queue
+    Properties:
+      KmsMasterKeyId: !Ref MainKmsKeyId
+
+  DeathDistributionTopicSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Protocol: sqs
+      Endpoint: !GetAtt DeathMinimisationQueue.Arn
+      TopicArn: !Ref DistributionTopicArn
+      RawMessageDelivery: true
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt DeathDistributionDlq.Arn
+
+  DeathMinimisationQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      KmsMasterKeyId: !Ref MainKmsKeyId
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt DeathMinimisationDlq.Arn
+        maxReceiveCount: 5
+
+  DeathMinimisationDlq:
+    Type: AWS::SQS::Queue
+    Properties:
+      KmsMasterKeyId: !Ref MainKmsKeyId
+
+  DeathDeliveryQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub ${NamePrefix}-delivery-queue-${Environment}${Developer}
+      KmsMasterKeyId: !Ref MainKmsKeyId
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt DeathDeliveryDlq.Arn
+        maxReceiveCount: 5
+
+  DeathDeliveryDlq:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub ${NamePrefix}-delivery-queue-dlq-${Environment}${Developer}
+      KmsMasterKeyId: !Ref MainKmsKeyId
+
+  DeathMinimisationFunction:
+    Type: AWS::Serverless::Function
+    DependsOn:
+      - DeathMinimisationFunctionLogGroup
+    Properties:
+      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
+      # checkov:skip=CKV_AWS_117: VPC settings are set globally.
+      # checkov:skip=CKV_AWS_173: Encryption settings are set globally.
+      FunctionName: !Sub ${NamePrefix}-death-minimisation-${Environment}${Developer}
+      CodeUri: ../lambdas/death-minimisation
+      Handler: uk.gov.di.data.lep.GroDeathMinimisation::handleRequest
+      Environment:
+        Variables:
+          POWERTOOLS_SERVICE_NAME: death-minimisation
+          TARGET_QUEUE: !GetAtt DeathDeliveryQueue.QueueUrl
+          ENRICHMENT_FIELDS: FORENAMES, SURNAME
+      AutoPublishAlias: latest
+      Events:
+        DeathEnrichedEvent:
+          Type: SQS
+          Properties:
+            Queue: !GetAtt DeathMinimisationQueue.Arn
+            BatchSize: 1
+      DeadLetterQueue:
+        Type: SQS
+        TargetArn: !GetAtt DeathMinimisationDlq.Arn
+      Policies:
+        - Statement:
+            - Sid: KmsMasterKeyAccess
+              Effect: Allow
+              Action:
+                - kms:Decrypt
+                - kms:GenerateDataKey
+              Resource:
+                - !Ref MainKmsKeyArn
+        - SQSSendMessagePolicy:
+            QueueName: !GetAtt DeathDeliveryQueue.QueueName
+      VpcConfig:
+        SubnetIds:
+          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
+          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
+          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
+      Tags:
+        CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_117.CKV_AWS_173
+
+  DeathMinimisationFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 14
+      LogGroupName: !Sub /aws/lambda/${NamePrefix}-death-minimisation-${Environment}${Developer}
+      KmsKeyId: !Ref MainKmsKeyArn
+
+  # Comment out CSLS subscription filters until accounts have been granted access
+  #  DeathMinimisationFunctionLogGroupSubscriptionFilter:
+  #    Type: AWS::Logs::SubscriptionFilter
+  #    Condition: IsNotDev
+  #    Properties:
+  #      DestinationArn: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
+  #      FilterPattern: ""
+  #      LogGroupName: !Ref DeathMinimisationFunctionLogGroup

--- a/sam/deathAcquirerTemplate.yaml
+++ b/sam/deathAcquirerTemplate.yaml
@@ -82,7 +82,6 @@ Conditions:
     Fn::Equals:
       - !Ref Environment
       - dev
-#  IsNotDev: !Not [ !Condition IsDev ]
 
 Resources:
   DeathSnsToSqsPolicy:
@@ -197,12 +196,3 @@ Resources:
       RetentionInDays: 14
       LogGroupName: !Sub /aws/lambda/${NamePrefix}-death-minimisation-${Environment}${Developer}
       KmsKeyId: !Ref MainKmsKeyArn
-
-  # Comment out CSLS subscription filters until accounts have been granted access
-  #  DeathMinimisationFunctionLogGroupSubscriptionFilter:
-  #    Type: AWS::Logs::SubscriptionFilter
-  #    Condition: IsNotDev
-  #    Properties:
-  #      DestinationArn: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
-  #      FilterPattern: ""
-  #      LogGroupName: !Ref DeathMinimisationFunctionLogGroup

--- a/samconfig.toml
+++ b/samconfig.toml
@@ -6,7 +6,7 @@ resolve_s3 = true
 s3_prefix = "oskwil-lev"
 region = "eu-west-2"
 confirm_changeset = true
-capabilities = "CAPABILITY_IAM"
+capabilities = "CAPABILITY_IAM CAPABILITY_AUTO_EXPAND"
 parameter_overrides = "Environment=\"dev\" VpcStackName=\"vpc\" Developer=\"oskwil\""
 
 [dev-hanleo.deploy.parameters]
@@ -15,7 +15,7 @@ resolve_s3 = true
 s3_prefix = "hanleo-lev"
 region = "eu-west-2"
 confirm_changeset = true
-capabilities = "CAPABILITY_IAM"
+capabilities = "CAPABILITY_IAM CAPABILITY_AUTO_EXPAND"
 parameter_overrides = "Environment=\"dev\" VpcStackName=\"vpc\" Developer=\"hanleo\""
 
 [dev-mwillis.deploy.parameters]
@@ -24,5 +24,5 @@ resolve_s3 = true
 s3_prefix = "mwillis-lev"
 region = "eu-west-2"
 confirm_changeset = true
-capabilities = "CAPABILITY_IAM"
+capabilities = "CAPABILITY_IAM CAPABILITY_AUTO_EXPAND"
 parameter_overrides = "Environment=\"dev\" VpcStackName=\"vpc\" Developer=\"mwillis\""

--- a/template.yaml
+++ b/template.yaml
@@ -263,65 +263,6 @@ Resources:
       KmsMasterKeyId: !Ref MainKmsKey
       TracingConfig: Active
 
-  DeathSnsToSqsPolicy:
-    Type: AWS::SQS::QueuePolicy
-    Properties:
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Sid: Allow SNS publish to SQS
-            Effect: Allow
-            Principal:
-              Service: sns.amazonaws.com
-            Resource: "*"
-            Action: SQS:SendMessage
-            Condition:
-              ArnEquals:
-                aws:SourceArn: !Ref DeathDistributionTopic
-      Queues:
-        - !GetAtt DeathMinimisationQueue.QueueUrl
-
-  DeathDistributionDlq:
-    Type: AWS::SQS::Queue
-    Properties:
-      KmsMasterKeyId: !Ref MainKmsKey
-
-  DeathDistributionTopicSubscription:
-    Type: AWS::SNS::Subscription
-    Properties:
-      Protocol: sqs
-      Endpoint: !GetAtt DeathMinimisationQueue.Arn
-      TopicArn: !GetAtt DeathDistributionTopic.TopicArn
-      RawMessageDelivery: true
-      RedrivePolicy:
-        deadLetterTargetArn: !GetAtt DeathDistributionDlq.Arn
-
-  DeathMinimisationQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      KmsMasterKeyId: !Ref MainKmsKey
-      RedrivePolicy:
-        deadLetterTargetArn: !GetAtt DeathMinimisationDlq.Arn
-        maxReceiveCount: 5
-
-  DeathMinimisationDlq:
-    Type: AWS::SQS::Queue
-    Properties:
-      KmsMasterKeyId: !Ref MainKmsKey
-
-  DeathDeliveryQueue:
-    Type: AWS::SQS::Queue
-    Properties:
-      KmsMasterKeyId: !Ref MainKmsKey
-      RedrivePolicy:
-        deadLetterTargetArn: !GetAtt DeathDeliveryDlq.Arn
-        maxReceiveCount: 5
-
-  DeathDeliveryDlq:
-    Type: AWS::SQS::Queue
-    Properties:
-      KmsMasterKeyId: !Ref MainKmsKey
-
   DeathValidationFunction:
     Type: AWS::Serverless::Function
     DependsOn:
@@ -444,67 +385,6 @@ Resources:
 #      DestinationArn: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
 #      FilterPattern: ""
 #      LogGroupName: !Ref DeathEnrichmentFunctionLogGroup
-
-  DeathMinimisationFunction:
-    Type: AWS::Serverless::Function
-    DependsOn:
-      - DeathMinimisationFunctionLogGroup
-    Properties:
-      # checkov:skip=CKV_AWS_115: We do not have enough data to allocate the concurrent execution allowance per function.
-      # checkov:skip=CKV_AWS_117: VPC settings are set globally.
-      # checkov:skip=CKV_AWS_173: Encryption settings are set globally.
-      FunctionName: !Sub death-minimisation-${Environment}${Developer}
-      CodeUri: lambdas/death-minimisation
-      Handler: uk.gov.di.data.lep.GroDeathMinimisation::handleRequest
-      Environment:
-        Variables:
-          POWERTOOLS_SERVICE_NAME: death-minimisation
-          TARGET_QUEUE: !GetAtt DeathDeliveryQueue.QueueUrl
-          ENRICHMENT_FIELDS: FORENAMES, SURNAME
-      AutoPublishAlias: latest
-      Events:
-        DeathEnrichedEvent:
-          Type: SQS
-          Properties:
-            Queue: !GetAtt DeathMinimisationQueue.Arn
-            BatchSize: 1
-      DeadLetterQueue:
-        Type: SQS
-        TargetArn: !GetAtt DeathMinimisationDlq.Arn
-      Policies:
-        - Statement:
-            - Sid: KmsMasterKeyAccess
-              Effect: Allow
-              Action:
-                - kms:Decrypt
-                - kms:GenerateDataKey
-              Resource:
-                - !GetAtt MainKmsKey.Arn
-        - SQSSendMessagePolicy:
-            QueueName: !GetAtt DeathDeliveryQueue.QueueName
-      VpcConfig:
-        SubnetIds:
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
-          - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
-      Tags:
-        CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_117.CKV_AWS_173
-
-  DeathMinimisationFunctionLogGroup:
-    Type: AWS::Logs::LogGroup
-    Properties:
-      RetentionInDays: 14
-      LogGroupName: !Sub /aws/lambda/death-minimisation-${Environment}${Developer}
-      KmsKeyId: !GetAtt MainKmsKey.Arn
-
-# Comment out CSLS subscription filters until accounts have been granted access
-#  DeathMinimisationFunctionLogGroupSubscriptionFilter:
-#    Type: AWS::Logs::SubscriptionFilter
-#    Condition: IsNotDev
-#    Properties:
-#      DestinationArn: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
-#      FilterPattern: ""
-#      LogGroupName: !Ref DeathMinimisationFunctionLogGroup
 
   LambdaSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -940,3 +820,19 @@ Resources:
       Description: The Public Key used to access the GRO SFTP server
       KmsKeyId: !Ref MainKmsKey
       Name: !Sub ${Environment}${Developer}-gro-sft-public-key
+
+  DwpDeathAcquirer:
+    Type: AWS::Serverless::Application
+    Properties:
+      Location: sam/deathAcquirerTemplate.yaml
+      Parameters:
+        Environment: !Ref Environment
+        VpcStackName: !Ref VpcStackName
+        Developer: !Ref Developer
+        DistributionTopicArn: !Ref DeathDistributionTopic
+        MainKmsKeyId: !Ref MainKmsKey
+        MainKmsKeyArn: !GetAtt MainKmsKey.Arn
+        LambdaSecurityGroupId: !Ref LambdaSecurityGroup
+        NamePrefix: dwp
+        CodeSigningConfigArn: !Ref CodeSigningConfigArn
+        PermissionsBoundary: !Ref PermissionsBoundary

--- a/template.yaml
+++ b/template.yaml
@@ -67,7 +67,6 @@ Conditions:
     Fn::Equals:
       - !Ref Environment
       - dev
-#  IsNotDev: !Not [ !Condition IsDev ]
 
 Mappings:
   EnvironmentConfiguration:
@@ -230,15 +229,6 @@ Resources:
       RetentionInDays: 14
       KmsKeyId: !GetAtt MainKmsKey.Arn
 
-# Comment out CSLS subscription filters until accounts have been granted access
-#  ApiGatewayLogGroupSubscriptionFilter:
-#    Type: AWS::Logs::SubscriptionFilter
-#    Condition: IsNotDev
-#    Properties:
-#      DestinationArn: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
-#      FilterPattern: ""
-#      LogGroupName: !Ref ApiGatewayLogGroup
-
   DeathValidationDlq:
     Type: AWS::SQS::Queue
     Properties:
@@ -317,15 +307,6 @@ Resources:
       LogGroupName: !Sub /aws/lambda/death-validation-${Environment}${Developer}
       KmsKeyId: !GetAtt MainKmsKey.Arn
 
-# Comment out CSLS subscription filters until accounts have been granted access
-#  DeathValidationFunctionLogGroupSubscriptionFilter:
-#    Type: AWS::Logs::SubscriptionFilter
-#    Condition: IsNotDev
-#    Properties:
-#      DestinationArn: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
-#      FilterPattern: ""
-#      LogGroupName: !Ref DeathValidationFunctionLogGroup
-
   DeathEnrichmentFunction:
     Type: AWS::Serverless::Function
     DependsOn:
@@ -376,15 +357,6 @@ Resources:
       RetentionInDays: 14
       LogGroupName: !Sub /aws/lambda/death-enrichment-${Environment}${Developer}
       KmsKeyId: !GetAtt MainKmsKey.Arn
-
-# Comment out CSLS subscription filters until accounts have been granted access
-#  DeathEnrichmentFunctionLogGroupSubscriptionFilter:
-#    Type: AWS::Logs::SubscriptionFilter
-#    Condition: IsNotDev
-#    Properties:
-#      DestinationArn: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
-#      FilterPattern: ""
-#      LogGroupName: !Ref DeathEnrichmentFunctionLogGroup
 
   LambdaSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -667,15 +639,6 @@ Resources:
       LogGroupName: !Sub /aws/lambda/gro-convert-to-json-${Environment}${Developer}
       KmsKeyId: !GetAtt MainKmsKey.Arn
 
-# Comment out CSLS subscription filters until accounts have been granted access
-#  GroConvertToJsonFunctionLogGroupSubscriptionFilter:
-#    Type: AWS::Logs::SubscriptionFilter
-#    Condition: IsNotDev
-#    Properties:
-#      DestinationArn: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
-#      FilterPattern: ""
-#      LogGroupName: !Ref GroConvertToJsonFunctionLogGroup
-
   GroPublishRecordFunction:
     Type: AWS::Serverless::Function
     DependsOn:
@@ -729,15 +692,6 @@ Resources:
       RetentionInDays: 14
       LogGroupName: !Sub /aws/lambda/gro-publish-record-${Environment}${Developer}
       KmsKeyId: !GetAtt MainKmsKey.Arn
-
-# Comment out CSLS subscription filters until accounts have been granted access
-#  GroPublishRecordFunctionLogGroupSubscriptionFilter:
-#    Type: AWS::Logs::SubscriptionFilter
-#    Condition: IsNotDev
-#    Properties:
-#      DestinationArn: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
-#      FilterPattern: ""
-#      LogGroupName: !Ref GroPublishRecordFunctionLogGroup
 
   GroPullFileFunction:
     Type: AWS::Serverless::Function
@@ -797,15 +751,6 @@ Resources:
       RetentionInDays: 14
       LogGroupName: !Sub /aws/lambda/gro-pull-file-${Environment}${Developer}
       KmsKeyId: !GetAtt MainKmsKey.Arn
-
-# Comment out CSLS subscription filters until accounts have been granted access
-#  GroPullFileFunctionLogGroupSubscriptionFilter:
-#    Type: AWS::Logs::SubscriptionFilter
-#    Condition: IsNotDev
-#    Properties:
-#      DestinationArn: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
-#      FilterPattern: ""
-#      LogGroupName: !Ref GroPullFileFunctionLogGroup
 
   GroSftpPrivateKeySecret:
     Type: AWS::SecretsManager::Secret


### PR DESCRIPTION
This allows for more resources and also allows for a nicer separation of our templates from one horrible file