### PR TITLE
GPC-NONE: Fix Permissions and Gro Json Record properties

### DIFF
--- a/lambdas/gro-convert-to-json/src/test/java/uk/gov/di/data/lep/ConvertToJsonTest.java
+++ b/lambdas/gro-convert-to-json/src/test/java/uk/gov/di/data/lep/ConvertToJsonTest.java
@@ -150,13 +150,13 @@ class ConvertToJsonTest {
             eq("JsonBucketName"),
             anyString(),
             matches(
-                "\"RegistrationID\":1.*" +
-                    "\"PersonGivenName\":.*\\[\"ERICA\",\"CHRISTINA\"\\].*" +
-                    "\"DeceasedGender\":2.*" +
-                    "\"RegistrationID\":2.*" +
-                    "\"PersonGivenName\":\\[\"BOB\"\\].*" +
-                    "\"DeceasedGender\":1.*" +
-                    "\"DeceasedBirthDate\":\\{\"PersonBirthDate\":\\[1958,6,6\\],\"VerificationLevel\":\"02\"\\}"
+                "\"registrationID\":1.*" +
+                    "\"personGivenNames\":.*\\[\"ERICA\",\"CHRISTINA\"\\].*" +
+                    "\"deceasedGender\":2.*" +
+                    "\"registrationID\":2.*" +
+                    "\"personGivenNames\":\\[\"BOB\"\\].*" +
+                    "\"deceasedGender\":1.*" +
+                    "\"deceasedBirthDate\":\\{\"personBirthDate\":\\[1958,6,6\\],\"verificationLevel\":\"02\"\\}"
             )
         );
     }
@@ -170,9 +170,9 @@ class ConvertToJsonTest {
         verify(awsService).putInBucket(
             eq("JsonBucketName"),
             anyString(),
-            matches("\"RegistrationID\":1.*" +
-                "\"PersonGivenName\":.*\\[\"ERICA\",\"CHRISTINA\"\\].*" +
-                "\"DeceasedGender\":2")
+            matches("\"registrationID\":1.*" +
+                "\"personGivenNames\":.*\\[\"ERICA\",\"CHRISTINA\"\\].*" +
+                "\"deceasedGender\":2")
         );
     }
 

--- a/lambdas/gro-publish-record/src/main/java/uk/gov/di/data/lep/PublishRecord.java
+++ b/lambdas/gro-publish-record/src/main/java/uk/gov/di/data/lep/PublishRecord.java
@@ -1,7 +1,6 @@
 package uk.gov.di.data.lep;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
@@ -23,7 +22,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
-public class PublishRecord implements RequestHandler<GroJsonRecord, Object> {
+public class PublishRecord {
     private final AwsService awsService;
     private final Config config;
     private final HttpClient httpClient;
@@ -41,14 +40,12 @@ public class PublishRecord implements RequestHandler<GroJsonRecord, Object> {
         this.objectMapper = objectMapper;
     }
 
-    @Override
     @Tracing
     @Logging(clearState = true)
-    public Object handleRequest(GroJsonRecord event, Context context) {
+    public void handleRequest(GroJsonRecord event, Context ignoredContext) {
         logger.info("Received record: {}", event.registrationID());
         var authorisationToken = getAuthorisationToken();
         postRecordToLifeEvents(event, authorisationToken);
-        return null;
     }
 
     // In this case, the fact that the thread has been interrupted is captured in our message and exception stack,

--- a/lambdas/gro-publish-record/src/test/java/uk/gov/di/data/lep/PublishRecordTest.java
+++ b/lambdas/gro-publish-record/src/test/java/uk/gov/di/data/lep/PublishRecordTest.java
@@ -10,8 +10,8 @@ import uk.gov.di.data.lep.dto.CognitoTokenResponse;
 import uk.gov.di.data.lep.exceptions.AuthException;
 import uk.gov.di.data.lep.exceptions.GroApiCallException;
 import uk.gov.di.data.lep.library.config.Config;
-import uk.gov.di.data.lep.library.dto.GroJsonRecordBuilder;
 import uk.gov.di.data.lep.library.dto.GroJsonRecord;
+import uk.gov.di.data.lep.library.dto.GroJsonRecordBuilder;
 import uk.gov.di.data.lep.library.exceptions.MappingException;
 import uk.gov.di.data.lep.library.services.AwsService;
 import uk.gov.di.data.lep.library.services.Mapper;
@@ -23,7 +23,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -106,11 +105,10 @@ class PublishRecordTest {
             ));
         when(objectMapper.writeValueAsString(event)).thenReturn(eventAsString);
 
-        var result = underTest.handleRequest(event, context);
+        underTest.handleRequest(event, context);
 
         verify(httpClient).send(expectedAuthRequest, HttpResponse.BodyHandlers.ofString());
         verify(httpClient).send(expectedGroRecordRequest, HttpResponse.BodyHandlers.ofString());
-        assertNull(result);
     }
 
     @Test

--- a/lib/src/main/java/uk/gov/di/data/lep/library/dto/GroAddressStructure.java
+++ b/lib/src/main/java/uk/gov/di/data/lep/library/dto/GroAddressStructure.java
@@ -1,19 +1,19 @@
 package uk.gov.di.data.lep.library.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 
 import java.util.List;
 
 public record GroAddressStructure(
-    @JsonProperty("Flat")
+    @JsonAlias("Flat")
     String flat,
-    @JsonProperty("Building")
+    @JsonAlias("Building")
     String building,
     @JacksonXmlElementWrapper(useWrapping = false)
-    @JsonProperty("Line")
+    @JsonAlias("Line")
     List<String> lines,
-    @JsonProperty("Postcode")
+    @JsonAlias("Postcode")
     String postcode
 ) {
 }

--- a/lib/src/main/java/uk/gov/di/data/lep/library/dto/GroJsonRecord.java
+++ b/lib/src/main/java/uk/gov/di/data/lep/library/dto/GroJsonRecord.java
@@ -1,7 +1,7 @@
 package uk.gov.di.data.lep.library.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import uk.gov.di.data.lep.library.config.Constants;
 import uk.gov.di.data.lep.library.enums.GenderAtRegistration;
@@ -10,49 +10,49 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record GroJsonRecord(
-    @JsonProperty("RegistrationID")
+    @JsonAlias("RegistrationID")
     Integer registrationID,
-    @JsonProperty("RegistrationType")
+    @JsonAlias("RegistrationType")
     Integer registrationType,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = Constants.LOCAL_DATE_TIME_PATTERN)
-    @JsonProperty("RecordLockedDateTime")
+    @JsonAlias("RecordLockedDateTime")
     LocalDateTime recordLockedDateTime,
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = Constants.LOCAL_DATE_TIME_PATTERN)
-    @JsonProperty("RecordUpdateDateTime")
+    @JsonAlias("RecordUpdateDateTime")
     LocalDateTime recordUpdateDateTime,
-    @JsonProperty("RecordUpdateReason")
+    @JsonAlias("RecordUpdateReason")
     Integer recordUpdateReason,
-    @JsonProperty("DeceasedName")
+    @JsonAlias("DeceasedName")
     GroPersonNameStructure deceasedName,
     @JacksonXmlElementWrapper(useWrapping = false)
-    @JsonProperty("DeceasedAliasName")
+    @JsonAlias("DeceasedAliasName")
     List<GroPersonNameStructure> deceasedAliasNames,
     @JacksonXmlElementWrapper(useWrapping = false)
-    @JsonProperty("DeceasedAliasNameType")
+    @JsonAlias("DeceasedAliasNameType")
     List<String> deceasedAliasNameTypes,
-    @JsonProperty("DeceasedMaidenName")
+    @JsonAlias("DeceasedMaidenName")
     String deceasedMaidenName,
-    @JsonProperty("DeceasedGender")
+    @JsonAlias("DeceasedGender")
     GenderAtRegistration deceasedGender,
-    @JsonProperty("DeceasedDeathDate")
+    @JsonAlias("DeceasedDeathDate")
     PersonDeathDateStructure deceasedDeathDate,
-    @JsonProperty("PartialMonthOfDeath")
+    @JsonAlias("PartialMonthOfDeath")
     Integer partialMonthOfDeath,
-    @JsonProperty("PartialYearOfDeath")
+    @JsonAlias("PartialYearOfDeath")
     Integer partialYearOfDeath,
-    @JsonProperty("QualifierText")
+    @JsonAlias("QualifierText")
     String qualifierText,
-    @JsonProperty("FreeFormatDeathDate")
+    @JsonAlias("FreeFormatDeathDate")
     String freeFormatDeathDate,
-    @JsonProperty("DeceasedBirthDate")
+    @JsonAlias("DeceasedBirthDate")
     PersonBirthDateStructure deceasedBirthDate,
-    @JsonProperty("PartialMonthOfBirth")
+    @JsonAlias("PartialMonthOfBirth")
     Integer partialMonthOfBirth,
-    @JsonProperty("PartialYearOfBirth")
+    @JsonAlias("PartialYearOfBirth")
     Integer partialYearOfBirth,
-    @JsonProperty("FreeFormatBirthDate")
+    @JsonAlias("FreeFormatBirthDate")
     String freeFormatBirthDate,
-    @JsonProperty("DeceasedAddress")
+    @JsonAlias("DeceasedAddress")
     GroAddressStructure deceasedAddress
 ) {
 }

--- a/lib/src/main/java/uk/gov/di/data/lep/library/dto/GroPersonNameStructure.java
+++ b/lib/src/main/java/uk/gov/di/data/lep/library/dto/GroPersonNameStructure.java
@@ -1,21 +1,21 @@
 package uk.gov.di.data.lep.library.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 
 import java.util.List;
 
 public record GroPersonNameStructure(
-    @JsonProperty("PersonNameTitle")
+    @JsonAlias("PersonNameTitle")
     String personNameTitle,
     @JacksonXmlElementWrapper(useWrapping = false)
-    @JsonProperty("PersonGivenName")
+    @JsonAlias("PersonGivenName")
     List<String> personGivenNames,
-    @JsonProperty("PersonFamilyName")
+    @JsonAlias("PersonFamilyName")
     String personFamilyName,
-    @JsonProperty("PersonNameSuffix")
+    @JsonAlias("PersonNameSuffix")
     String personNameSuffix,
-    @JsonProperty("PersonRequestedName")
+    @JsonAlias("PersonRequestedName")
     String personRequestedName
 ) {
 }

--- a/lib/src/main/java/uk/gov/di/data/lep/library/dto/PersonBirthDateStructure.java
+++ b/lib/src/main/java/uk/gov/di/data/lep/library/dto/PersonBirthDateStructure.java
@@ -1,16 +1,16 @@
 package uk.gov.di.data.lep.library.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.data.lep.library.enums.GroVerificationLevel;
 
 import java.time.LocalDate;
 
 public record PersonBirthDateStructure(
-    @JsonProperty("PersonBirthDate")
+    @JsonAlias("PersonBirthDate")
     LocalDate personBirthDate,
     @JsonIgnoreProperties(ignoreUnknown = true)
-    @JsonProperty("VerificationLevel")
+    @JsonAlias("VerificationLevel")
     GroVerificationLevel verificationLevel
 ) {
 }

--- a/lib/src/main/java/uk/gov/di/data/lep/library/dto/PersonDeathDateStructure.java
+++ b/lib/src/main/java/uk/gov/di/data/lep/library/dto/PersonDeathDateStructure.java
@@ -1,16 +1,16 @@
 package uk.gov.di.data.lep.library.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.data.lep.library.enums.GroVerificationLevel;
 
 import java.time.LocalDate;
 
 public record PersonDeathDateStructure(
-    @JsonProperty("PersonDeathDate")
+    @JsonAlias("PersonDeathDate")
     LocalDate personDeathDate,
     @JsonIgnoreProperties(ignoreUnknown = true)
-    @JsonProperty("VerificationLevel")
+    @JsonAlias("VerificationLevel")
     GroVerificationLevel verificationLevel
 ) {
 }

--- a/lib/src/main/java/uk/gov/di/data/lep/library/services/AwsService.java
+++ b/lib/src/main/java/uk/gov/di/data/lep/library/services/AwsService.java
@@ -1,6 +1,6 @@
 package uk.gov.di.data.lep.library.services;
 
-import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cognitoidentityprovider.CognitoIdentityProviderClient;
@@ -24,23 +24,23 @@ public class AwsService {
     private final Config config;
     private final CognitoIdentityProviderClient cognitoClient = CognitoIdentityProviderClient.builder()
         .region(Region.EU_WEST_2)
-        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+        .credentialsProvider(DefaultCredentialsProvider.create())
         .build();
     private final SecretsManagerClient secretsManagerClient = SecretsManagerClient.builder()
         .region(Region.EU_WEST_2)
-        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+        .credentialsProvider(DefaultCredentialsProvider.create())
         .build();
     private final SqsClient sqsClient = SqsClient.builder()
         .region(Region.EU_WEST_2)
-        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+        .credentialsProvider(DefaultCredentialsProvider.create())
         .build();
     private final SnsClient snsClient = SnsClient.builder()
         .region(Region.EU_WEST_2)
-        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+        .credentialsProvider(DefaultCredentialsProvider.create())
         .build();
     private final S3Client s3Client = S3Client.builder()
         .region(Region.EU_WEST_2)
-        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+        .credentialsProvider(DefaultCredentialsProvider.create())
         .build();
 
     public AwsService() {

--- a/lib/src/test/java/uk/gov/di/data/lep/library/services/AwsServiceTest.java
+++ b/lib/src/test/java/uk/gov/di/data/lep/library/services/AwsServiceTest.java
@@ -2,7 +2,7 @@ package uk.gov.di.data.lep.library.services;
 
 import org.junit.jupiter.api.Test;
 
-import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
@@ -46,17 +46,17 @@ class AwsServiceTest {
     @Test
     void putOnQueuePutsMessageOnQueue() {
         try (var staticClient = mockStatic(SqsClient.class);
-             var staticCredentialsProvider = mockStatic(EnvironmentVariableCredentialsProvider.class);
+             var staticCredentialsProvider = mockStatic(DefaultCredentialsProvider.class);
              var staticRequest = mockStatic(SendMessageRequest.class)) {
 
             var client = mock(SqsClient.class);
             var clientBuilder = mock(SqsClientBuilder.class);
-            var credentialsProvider = mock(EnvironmentVariableCredentialsProvider.class);
+            var credentialsProvider = mock(DefaultCredentialsProvider.class);
             var request = mock(SendMessageRequest.class);
             var requestBuilder = mock(SendMessageRequest.Builder.class);
 
             staticClient.when(SqsClient::builder).thenReturn(clientBuilder);
-            staticCredentialsProvider.when(EnvironmentVariableCredentialsProvider::create).thenReturn(credentialsProvider);
+            staticCredentialsProvider.when(DefaultCredentialsProvider::create).thenReturn(credentialsProvider);
             staticRequest.when(SendMessageRequest::builder).thenReturn(requestBuilder);
 
             when(config.getTargetQueue()).thenReturn("Target Queue");
@@ -83,17 +83,17 @@ class AwsServiceTest {
     @Test
     void putOnTopicPutsMessageOnTopic() {
         try (var staticClient = mockStatic(SnsClient.class);
-             var staticCredentialsProvider = mockStatic(EnvironmentVariableCredentialsProvider.class);
+             var staticCredentialsProvider = mockStatic(DefaultCredentialsProvider.class);
              var staticRequest = mockStatic(PublishRequest.class)) {
 
             var client = mock(SnsClient.class);
             var clientBuilder = mock(SnsClientBuilder.class);
-            var credentialsProvider = mock(EnvironmentVariableCredentialsProvider.class);
+            var credentialsProvider = mock(DefaultCredentialsProvider.class);
             var request = mock(PublishRequest.class);
             var requestBuilder = mock(PublishRequest.Builder.class);
 
             staticClient.when(SnsClient::builder).thenReturn(clientBuilder);
-            staticCredentialsProvider.when(EnvironmentVariableCredentialsProvider::create).thenReturn(credentialsProvider);
+            staticCredentialsProvider.when(DefaultCredentialsProvider::create).thenReturn(credentialsProvider);
             staticRequest.when(PublishRequest::builder).thenReturn(requestBuilder);
 
             when(config.getTargetTopic()).thenReturn("Target Topic");
@@ -120,18 +120,18 @@ class AwsServiceTest {
     @Test
     void getFromBucketGetsStringFromBucket() {
         try (var staticClient = mockStatic(S3Client.class);
-             var staticCredentialsProvider = mockStatic(EnvironmentVariableCredentialsProvider.class);
+             var staticCredentialsProvider = mockStatic(DefaultCredentialsProvider.class);
              var staticRequest = mockStatic(GetObjectRequest.class)) {
             var client = mock(S3Client.class);
             var clientBuilder = mock(S3ClientBuilder.class);
-            var credentialsProvider = mock(EnvironmentVariableCredentialsProvider.class);
+            var credentialsProvider = mock(DefaultCredentialsProvider.class);
             var request = mock(GetObjectRequest.class);
             var requestBuilder = mock(GetObjectRequest.Builder.class);
 
             var responseBytes = mock(ResponseBytes.class);
 
             staticClient.when(S3Client::builder).thenReturn(clientBuilder);
-            staticCredentialsProvider.when(EnvironmentVariableCredentialsProvider::create).thenReturn(credentialsProvider);
+            staticCredentialsProvider.when(DefaultCredentialsProvider::create).thenReturn(credentialsProvider);
             staticRequest.when(GetObjectRequest::builder).thenReturn(requestBuilder);
 
             when(clientBuilder.region(Region.EU_WEST_2)).thenReturn(clientBuilder);
@@ -160,18 +160,18 @@ class AwsServiceTest {
     @Test
     void putInBucketPutsStringInBucket() {
         try (var staticClient = mockStatic(S3Client.class);
-             var staticCredentialsProvider = mockStatic(EnvironmentVariableCredentialsProvider.class);
+             var staticCredentialsProvider = mockStatic(DefaultCredentialsProvider.class);
              var staticRequest = mockStatic(PutObjectRequest.class);
              var staticRequestBody = mockStatic(RequestBody.class)) {
             var client = mock(S3Client.class);
             var clientBuilder = mock(S3ClientBuilder.class);
-            var credentialsProvider = mock(EnvironmentVariableCredentialsProvider.class);
+            var credentialsProvider = mock(DefaultCredentialsProvider.class);
             var request = mock(PutObjectRequest.class);
             var requestBuilder = mock(PutObjectRequest.Builder.class);
             var requestBody = mock(RequestBody.class);
 
             staticClient.when(S3Client::builder).thenReturn(clientBuilder);
-            staticCredentialsProvider.when(EnvironmentVariableCredentialsProvider::create).thenReturn(credentialsProvider);
+            staticCredentialsProvider.when(DefaultCredentialsProvider::create).thenReturn(credentialsProvider);
             staticRequest.when(PutObjectRequest::builder).thenReturn(requestBuilder);
 
             staticRequestBody.when(() -> RequestBody.fromString("Content")).thenReturn(requestBody);
@@ -198,12 +198,12 @@ class AwsServiceTest {
     @Test
     void putInBucketPutsStreamInBucket() {
         try (var staticClient = mockStatic(S3Client.class);
-             var staticCredentialsProvider = mockStatic(EnvironmentVariableCredentialsProvider.class);
+             var staticCredentialsProvider = mockStatic(DefaultCredentialsProvider.class);
              var staticRequest = mockStatic(PutObjectRequest.class);
              var staticRequestBody = mockStatic(RequestBody.class)) {
             var client = mock(S3Client.class);
             var clientBuilder = mock(S3ClientBuilder.class);
-            var credentialsProvider = mock(EnvironmentVariableCredentialsProvider.class);
+            var credentialsProvider = mock(DefaultCredentialsProvider.class);
             var request = mock(PutObjectRequest.class);
             var requestBuilder = mock(PutObjectRequest.Builder.class);
             var requestBody = mock(RequestBody.class);
@@ -211,7 +211,7 @@ class AwsServiceTest {
             var inputStream = mock(InputStream.class);
 
             staticClient.when(S3Client::builder).thenReturn(clientBuilder);
-            staticCredentialsProvider.when(EnvironmentVariableCredentialsProvider::create).thenReturn(credentialsProvider);
+            staticCredentialsProvider.when(DefaultCredentialsProvider::create).thenReturn(credentialsProvider);
             staticRequest.when(PutObjectRequest::builder).thenReturn(requestBuilder);
 
             staticRequestBody.when(() -> RequestBody.fromInputStream(inputStream, 10)).thenReturn(requestBody);
@@ -238,18 +238,18 @@ class AwsServiceTest {
     @Test
     void getSecretGetsSecretValue() {
         try (var staticClient = mockStatic(SecretsManagerClient.class);
-             var staticCredentialsProvider = mockStatic(EnvironmentVariableCredentialsProvider.class);
+             var staticCredentialsProvider = mockStatic(DefaultCredentialsProvider.class);
              var staticRequest = mockStatic(GetSecretValueRequest.class)) {
             var client = mock(SecretsManagerClient.class);
             var clientBuilder = mock(SecretsManagerClientBuilder.class);
-            var credentialsProvider = mock(EnvironmentVariableCredentialsProvider.class);
+            var credentialsProvider = mock(DefaultCredentialsProvider.class);
             var request = mock(GetSecretValueRequest.class);
             var requestBuilder = mock(GetSecretValueRequest.Builder.class);
 
             var response = mock(GetSecretValueResponse.class);
 
             staticClient.when(SecretsManagerClient::builder).thenReturn(clientBuilder);
-            staticCredentialsProvider.when(EnvironmentVariableCredentialsProvider::create).thenReturn(credentialsProvider);
+            staticCredentialsProvider.when(DefaultCredentialsProvider::create).thenReturn(credentialsProvider);
             staticRequest.when(GetSecretValueRequest::builder).thenReturn(requestBuilder);
 
             when(clientBuilder.region(Region.EU_WEST_2)).thenReturn(clientBuilder);
@@ -276,11 +276,11 @@ class AwsServiceTest {
     @Test
     void getCognitoClientSecretGetsClientSecret() {
         try (var staticClient = mockStatic(CognitoIdentityProviderClient.class);
-             var staticCredentialsProvider = mockStatic(EnvironmentVariableCredentialsProvider.class);
+             var staticCredentialsProvider = mockStatic(DefaultCredentialsProvider.class);
              var staticRequest = mockStatic(DescribeUserPoolClientRequest.class)) {
             var client = mock(CognitoIdentityProviderClient.class);
             var clientBuilder = mock(CognitoIdentityProviderClientBuilder.class);
-            var credentialsProvider = mock(EnvironmentVariableCredentialsProvider.class);
+            var credentialsProvider = mock(DefaultCredentialsProvider.class);
             var request = mock(DescribeUserPoolClientRequest.class);
             var requestBuilder = mock(DescribeUserPoolClientRequest.Builder.class);
 
@@ -288,7 +288,7 @@ class AwsServiceTest {
             var userPoolClient = mock(UserPoolClientType.class);
 
             staticClient.when(CognitoIdentityProviderClient::builder).thenReturn(clientBuilder);
-            staticCredentialsProvider.when(EnvironmentVariableCredentialsProvider::create).thenReturn(credentialsProvider);
+            staticCredentialsProvider.when(DefaultCredentialsProvider::create).thenReturn(credentialsProvider);
             staticRequest.when(DescribeUserPoolClientRequest::builder).thenReturn(requestBuilder);
 
             when(clientBuilder.region(Region.EU_WEST_2)).thenReturn(clientBuilder);


### PR DESCRIPTION
The JsonProperty annotations doesn't work for Lambda mapping of input (so RegistrationID was not being parsed into registrationID when the PublishRecord lambda function was hit). As a result, we have updated the xml to json mapping to map to the lowercase and pluralised version of the JSON.

We also had incorrect permissions in the AWS service for our credentials provider